### PR TITLE
Fix typo in gates documentation

### DIFF
--- a/docs/start/concepts.rst
+++ b/docs/start/concepts.rst
@@ -54,7 +54,7 @@ How was it implemented?
 Gates, gates everywhere
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The area in front of the sensor is divided in 9 ranges called gates the documentation.
+The area in front of the sensor is divided in 9 ranges called gates in the documentation.
 
 The following table tells the range covered by each gate depending on the distance
 resolution setting:


### PR DESCRIPTION
Missing "in" the documentation.

Also, thanks for making this library. I've both learned a lot from using it and avoided learning a lot by not having to read and implement the protocol myself.